### PR TITLE
Update/flux explicit train

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1"
-Flux = "0.13"
+Flux = "0.13.11"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DenoisingDiffusion"
 uuid = "32e9e46b-ad0f-4c80-b32d-4f6f824844ef"
 authors = ["Lior Sinai <lior@bbd.co.za>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/examples/train_classifier.jl
+++ b/examples/train_classifier.jl
@@ -13,7 +13,7 @@ include("LeNet5.jl")
 
 #### settings
 seed = 2714
-data_directory = "C:\\Users\\sinai\\Documents\\Projects\\datasets\\MNIST"
+data_directory = "path\\to\\data"
 output_dir = "outputs\\LeNet5"
 mkpath(output_dir)
 

--- a/examples/train_classifier.jl
+++ b/examples/train_classifier.jl
@@ -3,7 +3,7 @@ using Flux: DataLoader, onehotbatch, onecold
 using Flux.Zygote: sensitivity, pullback
 using BSON, JSON
 using StatsBase: mean
-using DenoisingDiffusion: split_validation, count_observations, batched_metric
+using DenoisingDiffusion: split_validation, batched_metric, train!
 using ProgressMeter, Printf
 using Plots
 using MLDatasets
@@ -12,13 +12,12 @@ using Random
 include("LeNet5.jl")
 
 #### settings
-
 seed = 2714
-data_directory = "path\\to\\MNIST"
+data_directory = "C:\\Users\\sinai\\Documents\\Projects\\datasets\\MNIST"
 output_dir = "outputs\\LeNet5"
+mkpath(output_dir)
 
 ### data
-
 trainset = MNIST(Float32, :train, dir=data_directory)
 testset = MNIST(Float32, :test, dir=data_directory)
 
@@ -27,7 +26,8 @@ y = onehotbatch(trainset.targets, 0:9)
 X_test = reshape(testset.features, 28, 28, 1, :)
 y_test = onehotbatch(testset.targets, 0:9);
 
-train_x, val_x = split_validation(MersenneTwister(seed), X, y; frac=0.1)
+rng = MersenneTwister(seed)
+train_x, val_x = split_validation(rng, X, y; frac=0.1)
 println("train data:      ", size(train_x[1]), ", ", size(train_x[2]))
 println("validation data: ", size(val_x[1]), ", ", size(val_x[2]))
 
@@ -35,68 +35,39 @@ train_loader = Flux.DataLoader(train_x; batchsize=32, shuffle=true)
 val_loader = Flux.DataLoader(val_x; batchsize=32, shuffle=false)
 test_loader = Flux.DataLoader((X_test, y_test); batchsize=32, shuffle=false)
 
-# build model
-
+### build model
 model = LeNet5()
 display(model)
 println("")
 
-# definitions
-accuracy(ŷ, y) = mean(onecold(ŷ, 0:9) .== onecold(y, 0:9))
-loss(x, y) = Flux.logitcrossentropy(model(x), y)
-loss(x::Tuple) = loss(x[1], x[2])
-Flux.train!
-opt = ADAM(0.001)
+### definitions
+accuracy(ŷ::AbstractMatrix, y::AbstractMatrix) = mean(onecold(ŷ, 0:9) .== onecold(y, 0:9))
+loss(model, xy::Tuple) = Flux.logitcrossentropy(model(xy[1]), xy[2])
 
-test_acc = batched_metric(accuracy, test_loader, model)
-@printf("test accuracy for %d samples: %.2f%%\n", count_observations(test_loader), test_acc * 100)
-
-# custom training loop edited from Flux.jl/src/optimise/train.jl
-function train!(loss, model, data, opt, val_data, accuracy; num_epochs=10)
-    history = Dict(
-        "train_acc" => Float64[],
-        "val_acc" => Float64[],
-        "train_loss" => Float64[],
-        "val_loss" => Float64[],
-    )
-    for epoch in 1:num_epochs
-        losses = Vector{Float64}()
-        params = Flux.params(model)
-        progress = Progress(length(data); desc="epoch $epoch/$num_epochs")
-        for x in data
-            batch_loss, back = pullback(params) do
-                loss(x)
-            end
-            grads = back(sensitivity(batch_loss))
-            Flux.update!(opt, params, grads)
-            push!(losses, batch_loss)
-            ProgressMeter.next!(progress; showvalues=[("batch loss", @sprintf("%.5f", batch_loss))])
-        end
-        # update history
-        train_acc = batched_metric(accuracy, train_loader, model)
-        valid_acc = batched_metric(accuracy, val_loader, model)
-
-        push!(history["train_acc"], train_acc)
-        push!(history["val_acc"], valid_acc)
-        push!(history["train_loss"], mean(losses))
-        push!(history["val_loss"], batched_metric(loss, val_data))
-
-        @printf("train loss: %.5f ; ", history["train_loss"][end])
-        @printf("val loss: %.5f ; ", history["val_loss"][end])
-        @printf("train acc: %.2f%% ; ", history["train_acc"][end] * 100)
-        @printf("val acc: %.2f%% ; ", history["val_acc"][end] * 100)
-        println("")
-    end
-    history
+test_acc = batched_metric(model, accuracy, test_loader)
+val_loss = 0.0
+for x in val_loader
+    val_loss += loss(model, x)
 end
+val_loss /= length(val_loader)
+@printf("test accuracy for %d samples: %.2f%%\n", length(test_loader), test_acc * 100)
+@printf("mean val loss: %.4f\n", val_loss)
+
 println("training")
 start_time = time_ns()
-history = train!(loss, model, train_loader, opt, val_loader, accuracy; num_epochs=10)
+## The DenoisingDiffusion.train! method is meant for diffusion models but we can use it here.
+## Ideally at the end of each epoch one should calculate additional metrics like train loss and accuracies.
+## However with diffusion models these are expensive operations and so they are skipped.
+opt_state = Flux.setup(Adam(0.001), model)
+history = train!(
+    loss, model, train_loader, opt_state, val_loader
+    ; num_epochs=10,
+    )
 end_time = time_ns() - start_time
 println("done training")
 @printf "time taken: %.2fs\n" end_time / 1e9
 
-## save
+### save
 output_path = joinpath(output_dir, "model.bson")
 history_path = joinpath(output_dir, "history.json")
 
@@ -105,30 +76,19 @@ open(history_path, "w") do f
     JSON.print(f, history)
 end
 
-## test
+### test
+test_acc = batched_metric(model, accuracy, test_loader)
+@printf("test accuracy for %d samples: %.2f%%\n", length(test_loader), test_acc * 100)
 
-test_acc = batched_metric(accuracy, test_loader, model)
-@printf("test accuracy for %d samples: %.2f%%\n", count_observations(test_loader), test_acc * 100)
-
-epochs = 1:length(history["train_acc"])
-canvas_acc = plot(
-    epochs, history["train_acc"], label="train",
-    xlabel="epochs",
-    ylabel="accuracy",
-    legend=:right, # :best, :right
-    ylims=(0, 1),
-)
-plot!(canvas_acc, epochs, history["val_acc"], label="valid")
-plot!(canvas_acc, [epochs[end]], [test_acc], markershape=:star, label="test")
-
-epochs = 1:length(history["train_loss"])
+epochs = 1:length(history["mean_batch_loss"])
 canvas_loss = plot(
-    epochs, history["train_loss"], label="train",
-    xlabel="epochs",
+    epochs, history["mean_batch_loss"], label="mean batch loss",
+    xlabel="epoch",
     ylabel="loss",
     legend=:right, # :best, :right
     ylims=(0, Inf),
 )
-plot!(canvas_loss, epochs, history["val_loss"], label="valid")
+plot!(canvas_loss, epochs, history["val_loss"], label="validation")
 
-plot(canvas_loss, canvas_acc, plot_title="history", size=(800, 400), margin=3Plots.mm)
+println("press enter to finish")
+readline()

--- a/examples/train_generated_2d.jl
+++ b/examples/train_generated_2d.jl
@@ -1,6 +1,5 @@
 using Plots
 using Flux
-using Flux: Embedding
 using Dates
 using BSON, JSON
 using Printf
@@ -10,21 +9,19 @@ using DenoisingDiffusion: train!
 include("datasets.jl")
 include("utilities.jl")
 
-## settings
-
-directory = "outputs\\" * Dates.format(now(), "yyyymmdd_HHMM")
+### settings
+directory = joinpath("outputs", "2d_" * Dates.format(now(), "yyyymmdd_HHMM"))
 num_timesteps = 40
 n_batch = 10_000
 to_device = cpu
 d_hid = 16
 num_epochs = 100
 
-## data
-
+### data
 X = normalize_neg_one_to_one(make_spiral(n_batch))
+X_val = normalize_neg_one_to_one(make_spiral(floor(Int, 0.1 * n_batch)))
 
-## model
-
+### model
 model = ConditionalChain(
     Parallel(.+, Dense(2, d_hid), Chain(SinusoidalPositionEmbedding(num_timesteps, d_hid), Dense(d_hid, d_hid))),
     swish,
@@ -42,32 +39,25 @@ diffusion = GaussianDiffusion(Vector{Float32}, βs, (2,), model)
 ### train
 diffusion = diffusion |> to_device
 
-data = Flux.DataLoader(X |> to_device; batchsize=32, shuffle=true);
-X_val = normalize_neg_one_to_one(make_spiral(floor(Int, 0.1 * n_batch)))
+train_data = Flux.DataLoader(X |> to_device; batchsize=32, shuffle=true);
 val_data = Flux.DataLoader(X_val |> to_device; batchsize=32, shuffle=false);
 loss_type = Flux.mse;
 loss(diffusion, x) = p_losses(diffusion, loss_type, x; to_device=to_device)
 opt = Adam(0.001);
 
-start_time = time_ns()
-history = train!(loss, diffusion, data, opt, val_data; num_epochs=num_epochs)
-end_time = time_ns() - start_time
-println("\ndone training")
-@printf "time taken: %.2fs\n" end_time / 1e9
+println("Calculating initial loss")
+val_loss = 0.0
+for x in val_data
+    global val_loss
+    val_loss += loss(diffusion, x)
+end
+val_loss /= length(val_data)
+@printf("\nval loss: %.5f\n", val_loss)
 
-### save results
-
-mkdir(directory)
+mkpath(directory)
 output_path = joinpath(directory, "diffusion.bson")
 history_path = joinpath(directory, "history.json")
 hyperparameters_path = joinpath(directory, "hyperparameters.json")
-
-diffusion = diffusion |> cpu
-BSON.bson(output_path, Dict(:diffusion => diffusion))
-
-open(history_path, "w") do f
-    JSON.print(f, history)
-end
 
 hyperparameters = Dict(
     "num_timesteps" => num_timesteps,
@@ -77,17 +67,42 @@ hyperparameters = Dict(
     "loss_type" => "$loss_type",
     "d_hid" => d_hid,
 )
-
 open(hyperparameters_path, "w") do f
     JSON.print(f, hyperparameters)
 end
+println("saved hyperparameters to $hyperparameters_path")
+
+println("Starting training")
+start_time = time_ns()
+opt_state = Flux.setup(opt, diffusion)
+history = train!(loss, diffusion, train_data, opt_state, val_data; num_epochs=num_epochs)
+end_time = time_ns() - start_time
+println("\ndone training")
+@printf "time taken: %.2fs\n" end_time / 1e9
+
+### save results
+diffusion = diffusion |> cpu
+BSON.bson(output_path, Dict(:diffusion => diffusion))
+println("saved model to $output_path")
+
+open(history_path, "w") do f
+    JSON.print(f, history)
+end
+println("saved history to $history_path")
 
 ### plot results
 diffusion = diffusion |> cpu
 
-p = plot(1:length(history["train_loss"]), history["train_loss"], label="train_loss")
-plot!(p, 1:length(history["val_loss"]), history["val_loss"], label="val_loss")
-display(p)
+canvas_train = plot(
+    1:length(history["mean_batch_loss"]), history["mean_batch_loss"], label="mean batch_loss",
+    xlabel="epoch",
+    ylabel="loss",
+    legend=:right, # :best, :right
+    ylims=(0, Inf),
+    )
+plot!(canvas_train, 1:length(history["val_loss"]), history["val_loss"], label="val_loss")
+display(canvas_train)
+
 X0 = p_sample_loop(diffusion, 1000)
 p = scatter(X0[1, :], X0[2, :], alpha=0.5, label="",
     aspectratio=:equal,

--- a/examples/train_generated_2d_cond.jl
+++ b/examples/train_generated_2d_cond.jl
@@ -1,19 +1,16 @@
 using Plots
 using Flux
-using Flux: Embedding
 using Dates
 using BSON, JSON
 using Printf
 
-using Revise
 using DenoisingDiffusion
 using DenoisingDiffusion: train!
-includet("datasets.jl")
-includet("utilities.jl")
+include("datasets.jl")
+include("utilities.jl")
 
-## settings
-
-directory = "outputs\\" * Dates.format(now(), "yyyymmdd_HHMM")
+### settings
+directory = joinpath("outputs", "2d_cond_" * Dates.format(now(), "yyyymmdd_HHMM"))
 num_timesteps = 40
 n_batch = 9_000
 to_device = cpu
@@ -22,13 +19,14 @@ num_epochs = 100
 num_classes = 3
 p_uncond = 0.2
 
-## data
+### data
 nsamples_per_class = round(Int, n_batch / num_classes)
 X1 = normalize_neg_one_to_one(make_spiral(nsamples_per_class));
 X2 = normalize_neg_one_to_one(make_s_curve(nsamples_per_class));
 X3 = normalize_neg_one_to_one(make_moons(nsamples_per_class));
 
 X = hcat(X1, X2, X3)
+# label = 1 is for any/unguided diffusion
 labels = 1 .+ vcat(fill(1, nsamples_per_class), fill(2, nsamples_per_class), fill(3, nsamples_per_class))
 
 n_val = floor(Int, 0.1 * nsamples_per_class)
@@ -39,7 +37,7 @@ X3_val = normalize_neg_one_to_one(make_moons(n_val));
 X_val = hcat(X1_val, X2_val, X3_val)
 labels_val = 1 .+ vcat(fill(1, n_val), fill(2, n_val), fill(3, n_val))
 
-## model
+### model
 model = ConditionalChain(
     Parallel(
         .+, Dense(2, d_hid),
@@ -70,10 +68,10 @@ display(model)
 βs = linear_beta_schedule(num_timesteps, 8e-6, 9e-5)
 diffusion = GaussianDiffusion(Vector{Float32}, βs, (2,), model)
 
-### train
+#### train
 diffusion = diffusion |> to_device
 
-data = Flux.DataLoader((X, labels) |> to_device; batchsize=32, shuffle=true);
+train_data = Flux.DataLoader((X, labels) |> to_device; batchsize=32, shuffle=true);
 val_data = Flux.DataLoader((X_val, labels_val) |> to_device; batchsize=32, shuffle=false);
 loss_type = Flux.mse;
 loss(diffusion, x) = p_losses(diffusion, loss_type, x; to_device=to_device, p_uncond=p_uncond)
@@ -88,28 +86,10 @@ end
 val_loss /= length(val_data)
 @printf("\nval loss: %.5f\n", val_loss)
 
-
-start_time = time_ns()
-history = train!(loss, diffusion, data, opt, val_data; num_epochs=num_epochs)
-end_time = time_ns() - start_time
-println("\ndone training")
-@printf "time taken: %.2fs\n" end_time / 1e9
-
-### save results
-
-mkdir(directory)
+mkpath(directory)
 output_path = joinpath(directory, "diffusion.bson")
 history_path = joinpath(directory, "history.json")
 hyperparameters_path = joinpath(directory, "hyperparameters.json")
-
-diffusion = diffusion |> cpu
-BSON.bson(output_path, Dict(:diffusion => diffusion))
-println("saved model to $output_path")
-
-open(history_path, "w") do f
-    JSON.print(f, history)
-end
-println("saved history to $history_path")
 
 hyperparameters = Dict(
     "num_timesteps" => num_timesteps,
@@ -121,18 +101,42 @@ hyperparameters = Dict(
     "num_classes" => num_classes,
     "p_uncond" => p_uncond,
 )
-
 open(hyperparameters_path, "w") do f
     JSON.print(f, hyperparameters)
 end
 println("saved hyperparameters to $hyperparameters_path")
 
+println("training")
+start_time = time_ns()
+opt_state = Flux.setup(opt, diffusion)
+history = train!(loss, diffusion, train_data, opt_state, val_data; num_epochs=num_epochs)
+end_time = time_ns() - start_time
+println("\ndone training")
+@printf "time taken: %.2fs\n" end_time / 1e9
+
+### save results
+diffusion = diffusion |> cpu
+BSON.bson(output_path, Dict(:diffusion => diffusion))
+println("saved model to $output_path")
+
+open(history_path, "w") do f
+    JSON.print(f, history)
+end
+println("saved history to $history_path")
+
 ### plot results
 diffusion = diffusion |> cpu
 
-p = plot(1:length(history["train_loss"]), history["train_loss"], label="train_loss")
-plot!(p, 1:length(history["val_loss"]), history["val_loss"], label="val_loss")
-display(p)
+canvas_train = plot(
+    1:length(history["mean_batch_loss"]), history["mean_batch_loss"], label="mean batch_loss",
+    xlabel="epoch",
+    ylabel="loss",
+    legend=:right, # :best, :right
+    ylims=(0, Inf),
+    )
+plot!(canvas_train, 1:length(history["val_loss"]), history["val_loss"], label="val_loss")
+display(canvas_train)
+
 canvases = []
 for label in 1:4
     X0 = p_sample_loop(diffusion, 1000, label; guidance_scale=1.0f0)

--- a/examples/train_images.jl
+++ b/examples/train_images.jl
@@ -61,7 +61,7 @@ model = UNet(in_channels, model_channels, num_timesteps;
 βs = cosine_beta_schedule(num_timesteps, 0.008)
 diffusion = GaussianDiffusion(Vector{Float32}, βs, data_shape, model)
 ## load
-# BSON.@load "outputs\\MNIST_20220814_2214\\diffusion_opt.bson" diffusion opt
+# BSON.@load "outputs\\Pokemon_20230826_1615\\diffusion_opt.bson" diffusion opt_state
 
 display(diffusion.denoise_fn)
 println("")

--- a/examples/train_images_cond.jl
+++ b/examples/train_images_cond.jl
@@ -1,24 +1,23 @@
 using MLDatasets
-using Plots, Images
 using Flux
 using Dates
 using BSON, JSON
 using Printf
 using Random
 using ProgressMeter
+using Plots, Images
 
-using Revise
 using DenoisingDiffusion
-using DenoisingDiffusion: train!, split_validation, load_opt_state!
+using DenoisingDiffusion: train!, split_validation
 include("utilities.jl")
 
 ### settings
-
 num_timesteps = 100
 seed = 2714
 dataset = :MNIST
-data_directory = "path\\to\\MNIST"
-output_directory = "outputs\\$(dataset)_" * Dates.format(now(), "yyyymmdd_HHMM")
+data_directory = "C:\\Users\\sinai\\Documents\\Projects\\datasets\\MNIST"
+#output_directory = joinpath("outputs", "$(dataset)_" * Dates.format(now(), "yyyymmdd_HHMM"))
+output_directory = "outputs\\MNIST_20230826_1426"
 model_channels = 16
 learning_rate = 0.001
 batch_size = 32
@@ -50,13 +49,12 @@ model = UNetConditioned(in_channels, model_channels, num_timesteps;
     block_groups=8,
     channel_multipliers=(1, 2, 4),
     num_attention_heads=4,
-    combine_embeddings=combine_embeddings
+    combine_embeddings=combine_embeddings,
 )
 βs = cosine_beta_schedule(num_timesteps, 0.008)
 diffusion = GaussianDiffusion(Vector{Float32}, βs, data_shape, model)
 ## load
-# BSON.@load "outputs\\MNIST_20221031_16cond\\diffusion_opt.bson" diffusion opt
-# params_start = Flux.params(diffusion);
+# BSON.@load "outputs\\MNIST_20220814_2214\\diffusion_opt.bson" diffusion opt
 
 display(diffusion.denoise_fn)
 println("")
@@ -64,17 +62,21 @@ println("")
 ### train
 diffusion = diffusion |> to_device
 
-data = Flux.DataLoader(train_x |> to_device; batchsize=batch_size, shuffle=true);
+train_data = Flux.DataLoader(train_x |> to_device; batchsize=batch_size, shuffle=true);
 val_data = Flux.DataLoader(val_x |> to_device; batchsize=batch_size, shuffle=false);
 loss(diffusion, x) = p_losses(diffusion, loss_type, x; to_device=to_device, p_uncond=p_uncond)
-if isdefined(Main, :opt)
-    println("loading optimiser state")
-    load_opt_state!(opt, params_start, Flux.params(diffusion), to_device=to_device)
-    println("  length(opt.state) = ", length(opt.state))
+if isdefined(Main, :opt_state)
+    opt = extract_rule_from_tree(opt_state)
+    println("existing optimiser: ")
+    println("  ", opt)
+    print("transfering opt_state to device ... ")
+    opt_state = opt_state |> to_device
+    println("done")
 else
     println("defining new optimiser")
     opt = Adam(learning_rate)
     println("  ", opt)
+    opt_state = Flux.setup(opt, diffusion)
 end
 
 println("Calculating initial loss")
@@ -86,7 +88,7 @@ end
 val_loss /= length(val_data)
 @printf("\nval loss: %.5f\n", val_loss)
 
-mkdir(output_directory)
+mkpath(output_directory)
 println("made directory: ", output_directory)
 hyperparameters_path = joinpath(output_directory, "hyperparameters.json")
 output_path = joinpath(output_directory, "diffusion_opt.bson")
@@ -115,37 +117,47 @@ println("saved hyperparameters to $hyperparameters_path")
 
 println("Starting training")
 start_time = time_ns()
-history = train!(loss, diffusion, data, opt, val_data;
+history = train!(loss, diffusion, train_data, opt_state, val_data;
     num_epochs=num_epochs, save_after_epoch=true, save_dir=output_directory)
 end_time = time_ns() - start_time
 println("\ndone training")
 @printf "time taken: %.2fs\n" end_time / 1e9
 
 ### save results
-
 open(history_path, "w") do f
     JSON.print(f, history)
 end
 println("saved history to $history_path")
 
-params_device = Flux.params(diffusion);
-let diffusion = cpu(diffusion)
-    # save opt in case want to resume training
-    load_opt_state!(opt, params_device, Flux.params(diffusion), to_device=cpu)
-    BSON.bson(output_path, Dict(:diffusion => diffusion, :opt => opt))
+let diffusion = cpu(diffusion), opt_state = cpu(opt_state)
+    # save opt_state in case want to resume training
+    BSON.bson(
+        output_path, 
+        Dict(
+            :diffusion => diffusion, 
+            :opt_state => opt_state
+        )
+    )
 end
 println("saved model to $output_path")
 
 ### plot results
 
-p1 = plot(1:length(history["val_loss"]), history["val_loss"], label="val loss")
-display(p1)
+canvas_train = plot(
+    1:length(history["mean_batch_loss"]), history["mean_batch_loss"], label="mean batch_loss",
+    xlabel="epoch",
+    ylabel="loss",
+    legend=:right, # :best, :right
+    ylims=(0, Inf),
+    )
+plot!(canvas_train, 1:length(history["val_loss"]), history["val_loss"], label="val_loss")
+display(canvas_train)
 
 X0_all = p_sample_loop(diffusion, collect(1:11); guidance_scale=2.0f0, to_device=to_device);
 X0_all = X0_all |> cpu;
-imgs = convert2image(trainset, X0_all[:, :, 1, :]);
-p_all = plot([plot(imgs[:, :, i], title="digit=$(i-2)") for i in 1:11]..., ticks=nothing)
-display(p_all)
+imgs_all = convert2image(trainset, X0_all[:, :, 1, :]);
+canvas_samples = plot([plot(imgs_all[:, :, i], title="digit=$(i-2)") for i in 1:11]..., ticks=nothing)
+display(canvas_samples)
 
 for label in 1:11
     println("press enter for next label")
@@ -153,8 +165,8 @@ for label in 1:11
     X0 = p_sample_loop(diffusion, 12, label; guidance_scale=2.0f0, to_device=to_device)
     X0 = X0 |> cpu
     imgs = convert2image(trainset, X0[:, :, 1, :])
-    p0 = plot([plot(imgs[:, :, i]) for i in 1:12]..., plot_title="label=$label", ticks=nothing)
-    display(p0)
+    canvas = plot([plot(imgs[:, :, i]) for i in 1:12]..., plot_title="label=$label", ticks=nothing)
+    display(canvas)
 end
 
 println("press enter to finish")

--- a/examples/train_images_cond.jl
+++ b/examples/train_images_cond.jl
@@ -54,7 +54,7 @@ model = UNetConditioned(in_channels, model_channels, num_timesteps;
 βs = cosine_beta_schedule(num_timesteps, 0.008)
 diffusion = GaussianDiffusion(Vector{Float32}, βs, data_shape, model)
 ## load
-# BSON.@load "outputs\\MNIST_20220814_2214\\diffusion_opt.bson" diffusion opt
+# BSON.@load "outputs\\Pokemon_20230826_1615\\diffusion_opt.bson" diffusion opt_state
 
 display(diffusion.denoise_fn)
 println("")

--- a/examples/train_images_cond.jl
+++ b/examples/train_images_cond.jl
@@ -15,7 +15,7 @@ include("utilities.jl")
 num_timesteps = 100
 seed = 2714
 dataset = :MNIST
-data_directory = "C:\\Users\\sinai\\Documents\\Projects\\datasets\\MNIST"
+data_directory = "path\\to\\data"
 #output_directory = joinpath("outputs", "$(dataset)_" * Dates.format(now(), "yyyymmdd_HHMM"))
 output_directory = "outputs\\MNIST_20230826_1426"
 model_channels = 16

--- a/examples/utilities.jl
+++ b/examples/utilities.jl
@@ -1,6 +1,7 @@
 using StatsBase
 using LinearAlgebra
 using Images
+using Optimisers
 
 ## model sizes 
 
@@ -49,3 +50,16 @@ function img_WH_to_gray(img_WH::AbstractArray{T,N}) where {T,N}
     img = Images.colorview(Images.Gray, img_HW)
     img
 end
+
+## optimisers
+
+function extract_rule_from_tree(tree::Union{NamedTuple, Tuple})
+    for state in tree
+        rule = extract_rule_from_tree(state)
+        if !isnothing(rule)
+            return rule
+        end
+    end
+end
+
+extract_rule_from_tree(leaf::Optimisers.Leaf) = leaf.rule

--- a/examples/utilities.jl
+++ b/examples/utilities.jl
@@ -1,7 +1,7 @@
 using StatsBase
 using LinearAlgebra
 using Images
-using Optimisers
+using Optimisers: Leaf
 
 ## model sizes 
 
@@ -62,4 +62,4 @@ function extract_rule_from_tree(tree::Union{NamedTuple, Tuple})
     end
 end
 
-extract_rule_from_tree(leaf::Optimisers.Leaf) = leaf.rule
+extract_rule_from_tree(leaf::Leaf) = leaf.rule

--- a/src/GaussianDiffusion.jl
+++ b/src/GaussianDiffusion.jl
@@ -156,7 +156,7 @@ function predict_start_from_noise(diffusion::GaussianDiffusion, x_t::AbstractArr
     coeff1 .* x_t - coeff2 .* noise
 end
 
-function model_predictions(diffusion::GaussianDiffusion, x::AbstractArray, timesteps::AbstractVector{Int})
+function denoise(diffusion::GaussianDiffusion, x::AbstractArray, timesteps::AbstractVector{Int})
     noise = diffusion.denoise_fn(x, timesteps)
     x_start = predict_start_from_noise(diffusion, x, timesteps, noise)
     x_start, noise
@@ -172,7 +172,7 @@ function p_sample(
     diffusion::GaussianDiffusion, x::AbstractArray, timesteps::AbstractVector{Int}, noise::AbstractArray;
     clip_denoised::Bool=true, add_noise::Bool=true
 )
-    x_start, pred_noise = model_predictions(diffusion, x, timesteps)
+    x_start, pred_noise = denoise(diffusion, x, timesteps)
     if clip_denoised
         clamp!(x_start, -1, 1)
     end

--- a/src/GaussianDiffusion.jl
+++ b/src/GaussianDiffusion.jl
@@ -194,10 +194,10 @@ See `p_sample_loop_all` for a version which returns values for all timesteps.
 function p_sample_loop(diffusion::GaussianDiffusion, shape::NTuple; clip_denoised::Bool=true, to_device=cpu)
     T = eltype(eltype(diffusion))
     x = randn(T, shape) |> to_device
-    @showprogress "Sampling..." for i in diffusion.num_timesteps:-1:1
-        timesteps = fill(i, shape[end]) |> to_device
+    @showprogress "Sampling..." for t in diffusion.num_timesteps:-1:1
+        timesteps = fill(t, shape[end]) |> to_device
         noise = randn(T, size(x)) |> to_device
-        x, x_start = p_sample(diffusion, x, timesteps, noise; clip_denoised=clip_denoised, add_noise=(i != 1))
+        x, x_start = p_sample(diffusion, x, timesteps, noise; clip_denoised=clip_denoised, add_noise=(t != 1))
     end
     x
 end
@@ -219,10 +219,10 @@ function p_sample_loop_all(diffusion::GaussianDiffusion, shape::NTuple; clip_den
     x_all = Array{T}(undef, size(x)..., 0) |> to_device
     x_start_all = Array{T}(undef, size(x)..., 0) |> to_device
     tdim = ndims(x_all)
-    @showprogress "Sampling..." for i in diffusion.num_timesteps:-1:1
-        timesteps = fill(i, shape[end]) |> to_device
+    @showprogress "Sampling..." for t in diffusion.num_timesteps:-1:1
+        timesteps = fill(t, shape[end]) |> to_device
         noise = randn(T, size(x)) |> to_device
-        x, x_start = p_sample(diffusion, x, timesteps, noise; clip_denoised=clip_denoised, add_noise=(i != 1))
+        x, x_start = p_sample(diffusion, x, timesteps, noise; clip_denoised=clip_denoised, add_noise=(t != 1))
         x_all = cat(x_all, x, dims=tdim)
         x_start_all = cat(x_start_all, x_start, dims=tdim)
     end

--- a/src/GaussianDiffusion.jl
+++ b/src/GaussianDiffusion.jl
@@ -28,7 +28,7 @@ end
 eltype(::Type{<:GaussianDiffusion{V}}) where {V} = V
 
 Flux.@functor GaussianDiffusion
-Flux.trainable(g::GaussianDiffusion) = (g.denoise_fn,)
+Flux.trainable(g::GaussianDiffusion) = (; g.denoise_fn)
 
 function Base.show(io::IO, diffusion::GaussianDiffusion)
     V = typeof(diffusion).parameters[1]

--- a/src/ddim.jl
+++ b/src/ddim.jl
@@ -17,7 +17,7 @@ function ddim_sample(
     η::Float32=1.0f0,
     add_noise::Bool=true
     )
-    x_start, pred_noise = model_predictions(diffusion, x, timesteps)
+    x_start, pred_noise = denoise(diffusion, x, timesteps)
     if clip_denoised
         clamp!(x_start, -1, 1)
     end

--- a/src/ddim_guidance.jl
+++ b/src/ddim_guidance.jl
@@ -22,9 +22,9 @@ function ddim_sample(
     guidance_scale::AbstractFloat=1.0f0
     )
     if guidance_scale == 1.0f0
-        x_start, pred_noise = model_predictions(diffusion, x, timesteps, labels)
+        x_start, pred_noise = denoise(diffusion, x, timesteps, labels)
     else
-        x_start, pred_noise = _classifier_free_guidance(
+        x_start, pred_noise = classifier_free_guidance(
             diffusion, x, timesteps, labels; guidance_scale=guidance_scale
         )
     end

--- a/src/guidance.jl
+++ b/src/guidance.jl
@@ -148,9 +148,9 @@ function p_sample(
     guidance_scale::AbstractFloat=1.0f0
     )
     if guidance_scale == 1.0f0
-        x_start, pred_noise = model_predictions(diffusion, x, timesteps, labels)
+        x_start, pred_noise = denoise(diffusion, x, timesteps, labels)
     else
-        x_start, pred_noise = _classifier_free_guidance(
+        x_start, pred_noise = classifier_free_guidance(
             diffusion, x, timesteps, labels; guidance_scale=guidance_scale
         )
     end
@@ -165,7 +165,7 @@ function p_sample(
     x_prev, x_start
 end
 
-function model_predictions(
+function denoise(
     diffusion::GaussianDiffusion,
     x::AbstractArray,
     timesteps::AbstractVector{Int},
@@ -176,7 +176,7 @@ function model_predictions(
     x_start, noise
 end
 
-function _classifier_free_guidance(
+function classifier_free_guidance(
     diffusion::GaussianDiffusion,
     x::AbstractArray,
     timesteps::AbstractVector{Int},

--- a/src/models/embed.jl
+++ b/src/models/embed.jl
@@ -14,7 +14,7 @@ struct SinusoidalPositionEmbedding{W<:AbstractArray}
 end
 
 Flux.@functor SinusoidalPositionEmbedding
-Flux.trainable(emb::SinusoidalPositionEmbedding) = ()
+Flux.trainable(emb::SinusoidalPositionEmbedding) = (;) # not trainable
 
 function SinusoidalPositionEmbedding(in::Int, out::Int)
     W = make_positional_embedding(out, in)


### PR DESCRIPTION
Update to Flux 0.13.9 explicit training syntax.

From Flux 0.15 the old implicit syntax will be deprecated. This was originally scheduled for v0.14.

This PR also include code refactoring and some renaming of internal functions.