### PR TITLE
Feature/external embeddings

### DIFF
--- a/examples/train_images_cond.jl
+++ b/examples/train_images_cond.jl
@@ -29,11 +29,15 @@ num_classes = 10
 
 ### data
 
+#embeddings = Embedding(num_classes, 4 * model_channels)
+embeddings = SinusoidalPositionEmbedding(num_classes, 4 * model_channels)
 trainset = MNIST(Float32, :train, dir=data_directory);
 norm_data = normalize_neg_one_to_one(reshape(trainset.features, 28, 28, 1, :));
-labels = 2 .+ trainset.targets; # 1->default, 2->0, 3->1, ..., 9->11
-train_x, val_x = split_validation(MersenneTwister(seed), norm_data, labels);
+labels = 1 .+ trainset.targets; # 1->0, 3->1, .., 9->10
+train_embeddings = embeddings.weight[:, labels]
+train_x, val_x = split_validation(MersenneTwister(seed), norm_data, train_embeddings);
 
+println("emeddings:       ", size(embeddings.weight))
 println("train data:      ", size(train_x[1]), "--", size(train_x[2]))
 println("validation data: ", size(val_x[1]), "--", size(val_x[2]))
 
@@ -42,7 +46,6 @@ println("validation data: ", size(val_x[1]), "--", size(val_x[2]))
 in_channels = size(train_x[1], 3)
 data_shape = size(train_x[1])[1:3]
 model = UNetConditioned(in_channels, model_channels, num_timesteps;
-    num_classes=num_classes,
     block_layer=ResBlock,
     num_blocks_per_level=1,
     block_groups=8,
@@ -133,7 +136,8 @@ let diffusion = cpu(diffusion), opt_state = cpu(opt_state)
         output_path, 
         Dict(
             :diffusion => diffusion, 
-            :opt_state => opt_state
+            :opt_state => opt_state,
+            :embeddings => embeddings
         )
     )
 end
@@ -152,18 +156,19 @@ plot!(canvas_train, 1:length(history["val_loss"]), history["val_loss"], label="v
 savefig(canvas_train, joinpath(output_directory, "history.png"))
 display(canvas_train)
 
-all_classes = collect(1:num_classes)
+all_classes = to_device(embeddings.weight)
 X0_all = p_sample_loop(diffusion, all_classes; guidance_scale=2.0f0, to_device=to_device);
 X0_all = X0_all |> cpu;
 imgs_all = convert2image(trainset, X0_all[:, :, 1, :]);
-canvas_samples = plot([plot(imgs_all[:, :, i], title="digit=$(i-2)") for i in 1:num_classes]..., ticks=nothing)
+canvas_samples = plot([plot(imgs_all[:, :, i], title="digit=$(i-1)") for i in 1:num_classes]..., ticks=nothing)
 savefig(canvas_samples, joinpath(output_directory, "samples.png"))
 display(canvas_samples)
 
 for label in 1:num_classes
     println("press enter for next label")
     readline()
-    X0 = p_sample_loop(diffusion, 12, label; guidance_scale=2.0f0, to_device=to_device)
+    class_embedding = repeat(embeddings.weight[:, label], 1, 12) |> to_device
+    X0 = p_sample_loop(diffusion, class_embedding; guidance_scale=2.0f0, to_device=to_device)
     X0 = X0 |> cpu
     imgs = convert2image(trainset, X0[:, :, 1, :])
     canvas = plot([plot(imgs[:, :, i]) for i in 1:12]..., plot_title="label=$label", ticks=nothing)

--- a/src/guidance.jl
+++ b/src/guidance.jl
@@ -217,7 +217,7 @@ function classifier_free_guidance(
 
     x_double = cat(x, x, dims=ndims(x))
     timesteps_double = vcat(timesteps, timesteps)
-    unconditioned_embeddings = zeros(size(embeddings)...)
+    unconditioned_embeddings = zeros(T, size(embeddings)...)
     embeddings_both = hcat(embeddings, unconditioned_embeddings)
     noise_both = diffusion.denoise_fn(x_double, timesteps_double, embeddings_both)
 

--- a/src/guidance.jl
+++ b/src/guidance.jl
@@ -1,6 +1,7 @@
 """
     p_losses(diffusion, loss, x_start, timesteps, labels, noise)
     p_losses(diffusion, loss, x_start, labels; to_device=cpu)
+    p_losses(diffusion, loss, x_start, embeddings; to_device=cpu)
 
 Sample from ``q(x_t | x_0, c)`` and return the loss for the predicted noise.
 
@@ -11,14 +12,11 @@ function p_losses(
     loss,
     x_start::AbstractArray{T,N},
     timesteps::AbstractVector{Int},
-    labels::AbstractVector{Int},
+    labels_or_embeddings::AbstractVecOrMat,
     noise::AbstractArray
     ) where {T,N}
-    if (size(x_start, N) != length(labels))
-        throw(DimensionMismatch("batch size != label length, $N != $(length(labels))"))
-    end
     x = q_sample(diffusion, x_start, timesteps, noise)
-    model_out = diffusion.denoise_fn(x, timesteps, labels)
+    model_out = diffusion.denoise_fn(x, timesteps, labels_or_embeddings)
     loss(model_out, noise)
 end
 
@@ -26,22 +24,23 @@ function p_losses(
     diffusion::GaussianDiffusion,
     loss,
     x_start::AbstractArray,
-    labels::AbstractVector{Int},
+    labels_or_embeddings::AbstractVecOrMat,
     ; to_device=cpu
     )
     batch_size = size(x_start)[end]
-    @assert(batch_size == length(labels),
-        "batch size != label length, $batch_size != $(length(labels))"
+    label_batch_size = size(labels_or_embeddings)[end]
+    @assert(batch_size == label_batch_size,
+        "batch size != label length, $batch_size != $(label_batch_size)"
     )
     timesteps = rand(1:diffusion.num_timesteps, batch_size) |> to_device
     noise = randn(eltype(eltype(diffusion)), size(x_start)) |> to_device
-    p_losses(diffusion, loss, x_start, timesteps, labels, noise)
+    p_losses(diffusion, loss, x_start, timesteps, labels_or_embeddings, noise)
 end
 
 """
-    p_sample_loop(diffusion, shape, labels; 
+    p_sample_loop(diffusion, shape, labels_or_embeddings; 
         clip_denoised=true, to_device=cpu, guidance_scale=1.0f0)
-    p_sample_loop(diffusion, labels; options...)
+    p_sample_loop(diffusion, labels_or_embeddings; options...)
     p_sample_loop(diffusion, batch_size, label; options...)
 
 Generate new samples and denoise it to the first time step using the classifier free guidance algorithm.
@@ -50,7 +49,7 @@ See `p_sample_loop_all` for a version which returns values for all timesteps.
 Reference: [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598) by Jonathan Ho, Tim Salimans (2022)  
 """
 function p_sample_loop(
-    diffusion::GaussianDiffusion, shape::NTuple, labels::AbstractVector{Int}
+    diffusion::GaussianDiffusion, shape::NTuple, labels_or_embeddings::AbstractVecOrMat
     ; clip_denoised::Bool=true, to_device=cpu, guidance_scale::AbstractFloat=1.0f0
     )
     T = eltype(eltype(diffusion))
@@ -59,7 +58,7 @@ function p_sample_loop(
         timesteps = fill(i, shape[end]) |> to_device
         noise = randn(T, size(x)) |> to_device
         x, x_start = p_sample(
-            diffusion, x, timesteps, labels, noise
+            diffusion, x, timesteps, labels_or_embeddings, noise
             ; clip_denoised=clip_denoised, add_noise=(i != 1), guidance_scale=guidance_scale
         )
     end
@@ -76,8 +75,13 @@ function p_sample_loop(diffusion::GaussianDiffusion, labels::AbstractVector{Int}
     p_sample_loop(diffusion, (diffusion.data_shape..., batch_size), labels; options...)
 end
 
+function p_sample_loop(diffusion::GaussianDiffusion, embeddings::AbstractMatrix; options...)
+    batch_size = size(embeddings, 2)
+    p_sample_loop(diffusion, (diffusion.data_shape..., batch_size), embeddings; options...)
+end
+
 """
-    p_sample_loop_all(diffusion, shape, labels; 
+    p_sample_loop_all(diffusion, shape, labels_or_embeddings; 
         clip_denoised=true, to_device=cpu, guidance_scale=1.0f0)
     p_sample_loop_all(diffusion, labels; options...)
     p_sample_loop_all(diffusion, batch_size, label; options...)
@@ -88,7 +92,7 @@ See `p_sample_loop` for a version which returns only the final sample.
 Reference: [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598) by Jonathan Ho, Tim Salimans (2022)  
 """
 function p_sample_loop_all(
-    diffusion::GaussianDiffusion, shape::NTuple, labels::AbstractVector{Int}
+    diffusion::GaussianDiffusion, shape::NTuple, labels_or_embeddings::AbstractVecOrMat
     ; clip_denoised::Bool=true, to_device=cpu, guidance_scale::AbstractFloat=1.0f0
 )
     T = eltype(eltype(diffusion))
@@ -100,7 +104,7 @@ function p_sample_loop_all(
         timesteps = fill(i, shape[end]) |> to_device
         noise = randn(T, size(x)) |> to_device
         x, x_start = p_sample(
-            diffusion, x, timesteps, labels, noise
+            diffusion, x, timesteps, labels_or_embeddings, noise
             ; clip_denoised=clip_denoised, add_noise=(i != 1), guidance_scale=guidance_scale
         )
         x_all = cat(x_all, x, dims=dim_time)
@@ -121,8 +125,14 @@ function p_sample_loop_all(diffusion::GaussianDiffusion, labels::AbstractVector{
     p_sample_loop_all(diffusion, shape, labels; options...)
 end
 
+function p_sample_loop_all(diffusion::GaussianDiffusion, embeddings::AbstractVecOrMat; options...)
+    batch_size = size(embeddings, 2)
+    shape = (diffusion.data_shape..., batch_size)
+    p_sample_loop_all(diffusion, shape, embeddings; options...)
+end
+
 """
-    p_sample(diffusion, x, timesteps, labels, noise; 
+    p_sample(diffusion, x, timesteps, labels_or_embeddings, noise; 
         clip_denoised=true, add_noise::Bool=true, guidance_scale=1.0f0)
 
 The reverse process ``p(x_{t-1} | x_t, t, c)``. Denoise the data by one timestep conditioned on labels.
@@ -133,7 +143,7 @@ function p_sample(
     diffusion::GaussianDiffusion,
     x::AbstractArray,
     timesteps::AbstractVector{Int},
-    labels::AbstractVector{Int},
+    labels_or_embeddings::AbstractVecOrMat,
     noise::AbstractArray
     ;
     clip_denoised::Bool=true,
@@ -141,10 +151,10 @@ function p_sample(
     guidance_scale::AbstractFloat=1.0f0
     )
     if guidance_scale == 1.0f0
-        x_start, pred_noise = denoise(diffusion, x, timesteps, labels)
+        x_start, pred_noise = denoise(diffusion, x, timesteps, labels_or_embeddings)
     else
         x_start, pred_noise = classifier_free_guidance(
-            diffusion, x, timesteps, labels; guidance_scale=guidance_scale
+            diffusion, x, timesteps, labels_or_embeddings; guidance_scale=guidance_scale
         )
     end
     if clip_denoised
@@ -162,9 +172,9 @@ function denoise(
     diffusion::GaussianDiffusion,
     x::AbstractArray,
     timesteps::AbstractVector{Int},
-    labels::AbstractVector{Int}
+    labels_or_embeddings::AbstractVecOrMat
     )
-    noise = diffusion.denoise_fn(x, timesteps, labels)
+    noise = diffusion.denoise_fn(x, timesteps, labels_or_embeddings)
     x_start = predict_start_from_noise(diffusion, x, timesteps, noise)
     x_start, noise
 end
@@ -184,6 +194,32 @@ function classifier_free_guidance(
     labels_both = vcat(labels, fill(1, batch_size))
 
     noise_both = diffusion.denoise_fn(x_double, timesteps_double, labels_both)
+
+    inds = ntuple(Returns(:), ndims(x_double) - 1)
+    ϵ_cond = view(noise_both, inds..., 1:batch_size)
+    ϵ_uncond = view(noise_both, inds..., (batch_size+1):(2*batch_size))
+    noise = ϵ_uncond + guidance_scale_ * (ϵ_cond - ϵ_uncond)
+
+    x_start = predict_start_from_noise(diffusion, x, timesteps, noise)
+    x_start, noise
+end
+
+function classifier_free_guidance(
+    diffusion::GaussianDiffusion,
+    x::AbstractArray,
+    timesteps::AbstractVector{Int},
+    embeddings::AbstractMatrix
+    ; guidance_scale=1.0f0
+    )
+    T = eltype(eltype(diffusion))
+    guidance_scale_ = convert(T, guidance_scale)
+    batch_size = size(x)[end]
+
+    x_double = cat(x, x, dims=ndims(x))
+    timesteps_double = vcat(timesteps, timesteps)
+    unconditioned_embeddings = zeros(size(embeddings)...)
+    embeddings_both = hcat(embeddings, unconditioned_embeddings)
+    noise_both = diffusion.denoise_fn(x_double, timesteps_double, embeddings_both)
 
     inds = ntuple(Returns(:), ndims(x_double) - 1)
     ϵ_cond = view(noise_both, inds..., 1:batch_size)

--- a/src/train.jl
+++ b/src/train.jl
@@ -61,6 +61,18 @@ function randomly_set_unconditioned(
     labels
 end
 
+function randomly_set_unconditioned(
+    embeddings::AbstractMatrix; prob_uncond::Float64=0.20
+    )
+    # with probability prob_uncond we train without class conditioning
+    embeddings = copy(embeddings)
+    batch_size = size(embeddings, 2)
+    is_not_class_cond = rand(batch_size) .<= prob_uncond
+    T = eltype(embeddings)
+    embeddings[:, is_not_class_cond] .= zero(T)
+    embeddings 
+end
+
 function update_history!(model, history, loss, val_data; prob_uncond::Float64=0.0)
     val_loss = batched_loss(loss, model, val_data; prob_uncond=prob_uncond)
     push!(history["val_loss"], val_loss)

--- a/test/ddim.jl
+++ b/test/ddim.jl
@@ -26,14 +26,46 @@ end
 
 @testset "DDIM - guidance" begin
     num_timesteps = 100
+    model = ConditionalChain(
+        Parallel(
+            .+,
+            Dense(2, 16),
+            Embedding(num_timesteps => 16),
+            Embedding(5 => 16)
+        ),
+        Dense(16 => 2)
+    )
+    βs = cosine_beta_schedule(num_timesteps)
+    diffusion = GaussianDiffusion(Vector{Float32}, βs, (2,), model)
+
+    nsamples = 3
+    shape = (2, nsamples)
+    x = randn(Float32, shape)
+    noise = randn(Float32, size(x))
+    timesteps = fill(100, nsamples)
+    timesteps_next = fill(90, nsamples)
+    labels = rand(1:5, nsamples)
+    x_prev, x_start = ddim_sample(diffusion, x, timesteps, timesteps_next, labels, noise; η=1.0f0);
+    @test size(x_prev) == (2, nsamples)
+    @test size(x_start) == (2, nsamples)
+
+    X0s = ddim_sample_loop(diffusion, 10, labels; η=1.0f0);
+    @test size(X0s) == (2, nsamples)
+
+    label = 4
+    X0s = ddim_sample_loop(diffusion, 10, nsamples, label; η=1.0f0);
+    @test size(X0s) == (2, nsamples)
+end
+
+@testset "DDIM - embeddings" begin
+    num_timesteps = 100
     model = UNetConditioned(1, 4, num_timesteps;
-        num_classes=5,
         block_layer=ResBlock,
         num_blocks_per_level=1,
         block_groups=1,
         channel_multipliers=(1, 2),
         num_attention_heads=4
-    ) # 11_197 parameters
+    ) # 11_101 parameters
     βs = cosine_beta_schedule(num_timesteps)
     diffusion = GaussianDiffusion(Vector{Float32}, βs, (8, 8, 1,), model)
 
@@ -43,15 +75,11 @@ end
     noise = randn(Float32, size(x))
     timesteps = fill(100, nsamples)
     timesteps_next = fill(90, nsamples)
-    labels = rand(1:5, nsamples)
-    x_prev, x_start = ddim_sample(diffusion, x, timesteps, timesteps_next, labels, noise; η=1.0f0);
+    embeddings = rand(Float32, 4 * 4, nsamples)
+    x_prev, x_start = ddim_sample(diffusion, x, timesteps, timesteps_next, embeddings, noise; η=1.0f0);
     @test size(x_prev) == (8, 8, 1, nsamples)
     @test size(x_start) == (8, 8, 1, nsamples)
 
-    X0s = ddim_sample_loop(diffusion, 10, labels; η=1.0f0);
-    @test size(X0s) == (8, 8, 1, nsamples)
-
-    label = 4
-    X0s = ddim_sample_loop(diffusion, 10, nsamples, label; η=1.0f0);
+    X0s = ddim_sample_loop(diffusion, 10, embeddings; η=1.0f0);
     @test size(X0s) == (8, 8, 1, nsamples)
 end

--- a/test/models.jl
+++ b/test/models.jl
@@ -1,4 +1,3 @@
-
 @testset "ConvEmbed" begin
     model = ConvEmbed(1 => 8, 16; groups=8)
     x = rand(Float32, 28, 28, 1, 2)
@@ -51,10 +50,9 @@ end
 @testset "UNetConditioned" begin
     x = rand(Float32, 32, 32, 1, 3)
     t = rand(1:10, 3)
-    labels = rand(1:5, 3)
+    embeddings = rand(Float32, 8*4, 3)
 
     model = UNetConditioned(1, 8, 10; 
-        num_classes=5, 
         block_layer=ConvEmbed, 
         channel_multipliers=(1, 2)
     )
@@ -63,7 +61,10 @@ end
     output = model(x, t)
     @test size(output) == size(x)
 
-    @test_nowarn model(x, t, labels)
-    output = model(x, t)
+    @test_nowarn model(x, t, embeddings)
+    output = model(x, t, embeddings)
     @test size(output) == size(x)
+
+    embeddings_wrong = rand(Float32, 7, 3)
+    @test_throws DimensionMismatch model(x, t, embeddings_wrong)
 end


### PR DESCRIPTION
Pass in external embeddings to the `UNetConditioned` model.

This breaks `UNetConditioned` but all previous code works. 

Many functions now accept `labels_or_emebddings<:AbstractMatrix` instead of just `labels<:AbstractVector{Int}`.

The default/unconditioned label is a vector of zeros. Future work could allow this to be set by the user to any arbitrary vector.

This has been tested on the MNIST data set and results are comparable to those obtained previously.